### PR TITLE
Statements of disbursements fix

### DIFF
--- a/process_new_release/1_parse_disbursements/parse-disbursements.py
+++ b/process_new_release/1_parse_disbursements/parse-disbursements.py
@@ -12,25 +12,17 @@
 
     It expects a file (named in the disbursements_file variable below) created as the result of something like the following two operations:
        
-       pdftk 2010q1_singlevolume.pdf cat 10-3613 output disbursements-only.pdf
-       
-       pdftotext -layout disbursements-only.pdf
+       pdftotext -layout 2010q1_singlevolume.pdf
 
-
-    Update the:
-      * disbursements_file variable (input file, e.g. '2010q2-disbursements-only.txt')
-      * year (e.g. '2009', '2010')
-      * quarter (e.g. 'Q1', 'Q2') 
-   
-   WARNING: there's a hardcoded or clause with individual years in it - this should be refactored to be an array, or at least kept up to date. I added up to 2015.
+    The filename's first six characters must represent the quarter it represents. The file is passed to this script as its only argument:
+    
+       parse-disbursements.py 2010q1_singlevolume.txt
+      
+  
 '''
 
-disbursements_file = '2011q1-disbursements-only.txt'
-year = '2011'
-quarter = 'Q1'
-thisquarter = year + quarter
 
-import csv, re, sys
+import csv, re, sys, os
 
 BAD_LINE_RE = re.compile('^(Frm|Fmt|Sfmt|Jkt|VerDate|VOUCHER|OFFICIAL\sEXPENSES|MEMBERS\sREPRESENATION\sALLOW|PO|APPS06|PsN:|07:23|M:)')
 
@@ -38,7 +30,13 @@ BAD_LINE_RE = re.compile('^(Frm|Fmt|Sfmt|Jkt|VerDate|VOUCHER|OFFICIAL\sEXPENSES|
 def known_bad(line):
     return (not line) or BAD_LINE_RE.match(line) or 'dkrause' in line
 
-def main():
+def main(disbursements_file):
+    
+    path, filename = os.path.split(disbursements_file)
+    year = filename[:4]
+    quarter = filename[4:6].upper()
+    thisquarter = year + quarter
+    
     f = open(disbursements_file, "r")
 
     fsummary = csv.writer(open("%s%s-house-disburse-summary.csv" % (year, quarter), "w"), quoting=csv.QUOTE_ALL)
@@ -55,39 +53,42 @@ def main():
 
     oldrecip = None
 
-    regular_re = re.compile(r"""(\d{2}-\d{2})\s+            # date
-                            ([0-9A-Z]{2})\s+                # transaction code
-                            ([0-9A-Z\-]+)\s+                  # record id
-                            (.*?)                           # recipient
-                            (\d{2}/{1}\d{2}/{1}\d{2})\s+    # date-start
-                            (\d{2}/{1}\d{2}/{1}\d{2})       # date-end
-                            (.*?)\s+                        # description
-                            (-?[0-9,]+\.\d{2})              # amount
+    regular_re = re.compile(r"""(\d{2}-\d{2})[\s\.]+            # date
+                            (GL\sLAW|GL\sFRM|\w{2})[\s\.]+       # transaction code. missing GL LAW and GL FRM.
+                            ([0-9A-Z\-]+)[\s\.]+                # record id
+                            (.*?)[\s\.]+                        # recipient
+                            (\d{2}/{1}\d{2}/{1}\d{2})[\s\.]+    # date-start
+                            (\d{2}/{1}\d{2}/{1}\d{2})[\s\.]+    # date-end
+                            (.*?)[\s\.]+                        # description
+                            (-?[0-9,]+\.\d{2})                  # amount
                             """, re.VERBOSE)
-    personel_re = re.compile(r"""(.*?)                      # recipient
-                             (\d{2}/{1}\d{2}/{1}\d{2})\s+   # date-start
-                             (\d{2}/{1}\d{2}/{1}\d{2})      # date-end
-                             (.*?)\s+                       # description
-                             (-?[0-9,]+\.\d{2})             # amount
+    personnel_re = re.compile(r"""(.*?)[\s\.]+                  # recipient
+                             (\d{2}/{1}\d{2}/{1}\d{2})[\s\.]+   # date-start
+                             (\d{2}/{1}\d{2}/{1}\d{2})[\s\.]+   # date-end
+                             (.*?)[\s\.]+                       # description
+                             (-?[0-9,]+\.\d{2})                 # amount
                              """, re.VERBOSE)
-    summary_re = re.compile(r"""(.*?)\.+\s+         # category
-                            (-?[0-9,]+\.\d{2})\s+   # 2009
-                            (-?[0-9,]+\.\d{2})      # 2009-Q3
+    summary_re = re.compile(r"""(.*?)[\s\.]+                    # category
+                            (-?[0-9,]+\.\d{2})\s+               # 2009
+                            (-?[0-9,]+\.\d{2})                  # 2009-Q3
                             """, re.VERBOSE)
 
 
-    benefits_re = re.compile(r"""(\d{2}-\d{2})\s+            # date
-                            ([0-9A-Z]{2})\s+                # transaction code
-                            ([0-9A-Z]+)\s+                  # record id
-                            (.*?)                           # recipient
-                            \s+    # no dates
-                            (.*?)\s+                        # description
-                            (-?[0-9,]+\.\d{2})              # amount
+    benefits_re = re.compile(r"""(\d{2}-\d{2})[\s\.]+           # date
+                            (GL\sLAW|GL\sFRM|\w{2})[\s\.]+       # transaction code
+                            ([0-9A-Z]+)[\s\.]+                  # record id
+                            (.*?)                               # recipient
+                            [\s\.]+                             # no dates
+                            (.*?)[\s\.]+                        # description
+                            (-?[0-9,]+\.\d{2})                  # amount
                             """, re.VERBOSE)
 
 
+    """'Ditto last line' is not used in newer filings."""
+    ditto_re = re.compile(r"""\s*DO[\s\.]+$""")
 
-    ditto_re = re.compile(r"""\s*DO[\s\.]*""")
+
+    year_re = re.compile('20(\d{2})\s*')
 
 
     transcodes = {
@@ -117,7 +118,15 @@ def main():
 'S5': 'Telecommunication services',
 'S6': 'District Office rent in space leased from GSA',
 'S7': 'Transit Benefits',
-'S8': 'equipment plan or maintenance provided through the CAO' } 
+'S8': 'equipment plan or maintenance provided through the CAO',
+
+#less detailed codes, used for newer quarters :(
+'AP': 'Accounts payable',
+'AR': 'Accounts receivable', 
+'GL': 'General ledger',
+'GL LAW': 'charges for purchase of services for Public Law documentation',
+'GL FRM': 'Interface charge for goods purchased through Framing Office'
+ } 
 
 
     for l in f.readlines():
@@ -128,8 +137,7 @@ def main():
         
 
         # new member
-        #TODO: refactor this to use an array
-        if l.startswith("2015 ") or l.startswith("2014 ") or l.startswith("2013 ") or l.startswith("2012 ") or l.startswith("2011 ") or l.startswith("2010 ") or l.startswith("2008 ") or l.startswith("2009 ") or l.startswith('2007 ') or l.startswith("FISCAL YEAR "):
+        if year_re.match(l) or l.startswith("FISCAL YEAR "):
             if l.startswith("FISCAL YEAR "):
                 thismem = l.replace('—', '')[17:]
                 thisyear = l[:16]
@@ -149,10 +157,10 @@ def main():
         ma = regular_re.search(l)
         if ma:
             m = ma.groups()
-            date1 = m[0].replace('–', '-')
+            date1 = m[0]
             transcode = m[1]
             recordid = m[2]
-            recip = m[3].strip().rstrip('.').rstrip('\t')
+            recip = m[3]
             sunrecip = recip
             if ditto_re.match(recip):
                 sunrecip = oldrecip
@@ -162,22 +170,22 @@ def main():
                 sunrecip=recip
             date2 = m[4]
             date3 = m[5]
-            descrip = m[6].strip().rstrip('.')
+            descrip = m[6]
             amount = m[7]
 
             transcodelong = ''
             if transcode in transcodes:
                 transcodelong = transcodes[transcode]
 
-            #fdetail.writerow([thismem, thisquarter, thisyear, thiscat, date1, transcode, recordid, sunrecip, recip, date2, date3, descrip, amount])
+
             fdetail.writerow([thismem, thisquarter, thiscat, date1, sunrecip, date2, date3, descrip, amount, thisyear, transcode, transcodelong, recordid, recip])
             continue
 
-        # personell record
-        ma = personel_re.search(l)
+        # personnel record
+        ma = personnel_re.search(l)
         if ma:
             m = ma.groups()
-            recip = m[0].strip().rstrip('.')
+            recip = m[0]
             sunrecip = recip
             if ditto_re.match(recip):
                 sunrecip = oldrecip
@@ -185,10 +193,8 @@ def main():
                 oldrecip = recip
             date2 = m[1]
             date3 = m[2]
-            descrip = m[3].strip().rstrip('.')
+            descrip = m[3]
             amount = m[4]
-            #fdetail.writerow( ['OFFICE','QUARTER','CATEGORY','DATE','PAYEE','START DATE','END DATE','PURPOSE','AMOUNT','YEAR', 'TRANSCODE','TRANSCODELONG','RECORDID','RECIP (orig.)'] )
-            #fdetail.writerow([thismem, thisquarter, thisyear, thiscat, "", "", "", sunrecip, recip, date2, date3, descrip, amount])
             fdetail.writerow([thismem, thisquarter, thiscat, "", sunrecip, date2, date3, descrip, amount, thisyear, "","","", recip ])
             continue
 
@@ -199,15 +205,15 @@ def main():
         ma = benefits_re.search(l)
         if ma:
             m = ma.groups()
-            recip = m[3].strip().rstrip('.')
+            recip = m[3]
             sunrecip = recip
             if ditto_re.match(recip):
                 sunrecip = oldrecip
             else:
                 oldrecip = recip
-            descrip = m[4].strip().rstrip('.')
+            descrip = m[4]
             amount = m[5]
-            date1 = m[0].replace('–', '-')
+            date1 = m[0]
             transcode = m[1]
             recordid = m[2]
             transcodelong = ''
@@ -215,8 +221,7 @@ def main():
                 transcodelong = transcodes[transcode]
 
 
-            #fdetail.writerow( ['OFFICE','QUARTER','CATEGORY','DATE','PAYEE','START DATE','END DATE','PURPOSE','AMOUNT','YEAR', 'TRANSCODE','TRANSCODELONG','RECORDID','RECIP (orig.)'] )
-            print [thismem, thisquarter, thiscat, date1, sunrecip, "","", descrip, amount, thisyear, transcode,transcodelong,recordid, recip ]
+
             fdetail.writerow([thismem, thisquarter, thiscat, date1, sunrecip, "","", descrip, amount, thisyear, transcode,transcodelong,recordid, recip ])
             continue
 
@@ -236,4 +241,5 @@ def main():
             trashcan.write(l)
 
 if __name__ == '__main__':
-    main()
+    infile = sys.argv[1]
+    main(infile)

--- a/process_new_release/1_parse_disbursements/parse-disbursements.py
+++ b/process_new_release/1_parse_disbursements/parse-disbursements.py
@@ -2,21 +2,19 @@
 # -*- coding: utf-8 -*-
 
 '''
-    This script was used to convert the 2009 Q3 House Disbursement PDF into detail and summary CSV files.
+    This script is used to convert House Disbursement PDFs into detail and summary CSV files.
         Source PDF: http://disbursements.house.gov/
         Resulting Data: http://www.sunlightfoundation.com/projects/2009/expenditures/
 
     It was originally authored by Luke Rosiak with improvements by James Turk for Sunlight Labs and is released into the public domain.
 
-    Disclaimer: It was written quickly under deadline and likely contains a few bugs - patches welcome
-
     It expects a file (named in the disbursements_file variable below) created as the result of something like the following operation:
        
        pdftotext -layout 2010q1_singlevolume.pdf
 
-    The filename's first six characters must represent the quarter it represents. The file is passed to this script as its only argument:
+    The filename's first six characters must represent the quarter it covers. The file is passed to this script as its only argument:
     
-       parse-disbursements.py 2010q1_singlevolume.txt
+       python parse-disbursements.py 2010q1_singlevolume.txt
       
   
 '''
@@ -84,7 +82,7 @@ def main(disbursements_file):
                             """, re.VERBOSE)
 
 
-    year_re = re.compile(r"""\s*(FISCAL YEAR)?\s*20([01]\d)\s*""")
+    year_re = re.compile(r"""(FISCAL YEAR\s+)?20([01]\d)\s+(\w+.*)\s*""")
 
 
     transcodes = {


### PR DESCRIPTION
Parse-disbursements.py now takes text file name as argument; regex fix to avoid mistaking all payee=do\* records as 'ditto's and thus wrongly replacing them with the recipient above them; add the House's new transaction codes.
